### PR TITLE
Private wikis

### DIFF
--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -43,7 +43,6 @@ class WikisController < ApplicationController
 
   def destroy
     @wiki = Wiki.find(params[:id])
-    authorize @wiki
     
     if @wiki.destroy
      flash[:notice] = "\"#{@wiki.title}\" was deleted successfully."

--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -1,6 +1,7 @@
 class WikisController < ApplicationController
   def index
-    @wikis = Wiki.all.sort_by{|a|a.title}
+    # @wikis = Wiki.all.sort_by{|a|a.title}
+    @wikis = policy_scope(Wiki).all.sort_by{|a|a.title}
   end
 
   def show
@@ -30,9 +31,9 @@ class WikisController < ApplicationController
   end
 
   def update
-    @wiki = Wiki.find(params[:id])
+    @wiki = Wiki.find(wiki_params)
     
-    if @wiki.update_attributes(params.require(:wiki).permit(:title, :body))
+    if @wiki.update_attributes(wiki_params)
      flash[:notice] = "Wiki article was updated."
      redirect_to @wiki
     else
@@ -50,6 +51,10 @@ class WikisController < ApplicationController
     else
      flash[:error] = "There was an error deleting the wiki."
      render :show
-   end
+    end
+  end
+
+  def wiki_params
+    params.require(:wiki).permit(:title, :body, :public)
   end
 end

--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -54,16 +54,16 @@ class WikisController < ApplicationController
     end
   end
 
-  def public_wiki_to_private
-    @wiki = Wiki.find(params[:public])
+  # def public_wiki_to_private
+  #   @wiki = Wiki.find(params[:public])
     
-    if @wiki.update_attributes(public: false)
-      flash[:notice] = "Wiki changed to Private."
-      redirect_to @wiki
-    else
-      flash[:error] = "There was an error updating the wiki."
-    end
-  end
+  #   if @wiki.update_attributes(public: false)
+  #     flash[:notice] = "Wiki changed to Private."
+  #     redirect_to @wiki
+  #   else
+  #     flash[:error] = "There was an error updating the wiki."
+  #   end
+  # end
 
   private
 

--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -13,6 +13,7 @@ class WikisController < ApplicationController
 
   def create
     @wiki = Wiki.new(params.require(:wiki).permit(:title, :body))
+    authorize @wiki
     
     if @wiki.save
       flash[:notice] = "Wiki article was saved."
@@ -25,6 +26,7 @@ class WikisController < ApplicationController
 
   def edit
     @wiki = Wiki.find(params[:id])
+    authorize @wiki
   end
 
   def update

--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -1,11 +1,11 @@
 class WikisController < ApplicationController
   def index
-    # @wikis = Wiki.all.sort_by{|a|a.title}
     @wikis = policy_scope(Wiki).all.sort_by{|a|a.title}
   end
 
   def show
     @wiki = Wiki.find(params[:id])
+    authorize @wiki
   end
 
   def new
@@ -31,9 +31,9 @@ class WikisController < ApplicationController
   end
 
   def update
-    @wiki = Wiki.find(wiki_params)
+    @wiki = Wiki.find(params[:id])
     
-    if @wiki.update_attributes(wiki_params)
+    if @wiki.update_attributes(params.require(:wiki).permit(:title, :body, :public))
      flash[:notice] = "Wiki article was updated."
      redirect_to @wiki
     else
@@ -54,7 +54,20 @@ class WikisController < ApplicationController
     end
   end
 
+  def public_wiki_to_private
+    @wiki = Wiki.find(params[:public])
+    
+    if @wiki.update_attributes(public: false)
+      flash[:notice] = "Wiki changed to Private."
+      redirect_to @wiki
+    else
+      flash[:error] = "There was an error updating the wiki."
+    end
+  end
+
+  private
+
   def wiki_params
-    params.require(:wiki).permit(:title, :body, :public)
+    params.require(:wiki).permit(:id, :title, :body, :public)
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,3 +1,0 @@
-class Subscription < ActiveRecord::Base
-  belongs_to :user
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,6 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable, :confirmable
 
   before_create :default_user_role_standard
-  has_one :subscription
 
   def standard?
     role == 'standard'
@@ -17,10 +16,6 @@ class User < ActiveRecord::Base
   def admin?
     role == 'admin'
   end
-
-  # def premium_to_standard
-  #   update_attributes(:role => 'standard')
-  # end
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ActiveRecord::Base
   
+  has_many :wikis, dependent: :update
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable, :confirmable
 
@@ -22,4 +23,6 @@ class User < ActiveRecord::Base
   def default_user_role_standard
     self.role ||= 'standard'
   end
+
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ActiveRecord::Base
   
-  has_many :wikis, dependent: :update
+  has_many :wikis
+  after_update :publicize_wikis_if_standard
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable, :confirmable
 
@@ -18,6 +19,15 @@ class User < ActiveRecord::Base
     role == 'admin'
   end
 
+  def publicize_wikis_if_standard
+    if standard?
+      wikis.each do |wiki|
+        wiki.public = true
+        wiki.save
+      end
+    end
+  end
+  
   private
 
   def default_user_role_standard

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -1,3 +1,5 @@
 class Wiki < ActiveRecord::Base
   belongs_to :user
+
+  scope :visible_to, -> (user) { user ? all : where(public: true) }
 end

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -1,16 +1,16 @@
 class Wiki < ActiveRecord::Base
   belongs_to :user
   before_create :default_wiki_public
-  after_update if: :private_to_public_wiki?
+  # after_update if: :private_to_public_wiki?
   
   scope :public_visible_to, -> (wiki) { wiki ? all : where(public: true) }
   scope :private_visible_to, -> (wiki) { wiki ? all : where(public: false) }
   
   # When a Private User downgrades to Standard, private wikis associated with that User 
   # change to public 
-  def private_to_public_wiki
-    wiki.update_attributes(public: true)
-  end
+  # def private_to_public_wiki
+  #   wiki.update_attributes(public: true)
+  # end
 
   def default_wiki_public
     self.public ||= true

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -1,5 +1,17 @@
 class Wiki < ActiveRecord::Base
   belongs_to :user
+  before_create :default_wiki_public
+  
+  scope :public_visible_to, -> (wiki) { wiki ? all : where(public: true) }
+  scope :private_visible_to, -> (wiki) { wiki ? all : where(public: false) }
 
-  scope :visible_to, -> (user) { user ? all : where(public: true) }
+  if current_user.role == 'admin' || current_user.role == 'premium'
+    wiki.public_visible_to.private_visible_to
+  else
+    wiki.public_visible_to
+  end
+
+  def default_wiki_public
+    self.public ||= true
+  end
 end

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -1,9 +1,16 @@
 class Wiki < ActiveRecord::Base
   belongs_to :user
   before_create :default_wiki_public
+  after_update if: :private_to_public_wiki?
   
   scope :public_visible_to, -> (wiki) { wiki ? all : where(public: true) }
   scope :private_visible_to, -> (wiki) { wiki ? all : where(public: false) }
+  
+  # When a Private User downgrades to Standard, private wikis associated with that User 
+  # change to public 
+  def private_to_public_wiki
+    wiki.update_attributes(public: true)
+  end
 
   def default_wiki_public
     self.public ||= true

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -5,12 +5,6 @@ class Wiki < ActiveRecord::Base
   scope :public_visible_to, -> (wiki) { wiki ? all : where(public: true) }
   scope :private_visible_to, -> (wiki) { wiki ? all : where(public: false) }
 
-  if current_user.role == 'admin' || current_user.role == 'premium'
-    wiki.public_visible_to.private_visible_to
-  else
-    wiki.public_visible_to
-  end
-
   def default_wiki_public
     self.public ||= true
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -19,15 +19,15 @@ class ApplicationPolicy
   end
 
   def new?
-    create?
+    false
   end
 
   def update?
-    user.present?
+    false
   end
 
   def edit?
-    update?
+    false
   end
 
   def destroy?

--- a/app/policies/wiki_policy.rb
+++ b/app/policies/wiki_policy.rb
@@ -4,24 +4,28 @@ class WikiPolicy < ApplicationPolicy
     false
   end
 
+  def show?
+    record.public? || user.present?
+  end
+
   def create?
-    user.present?
+    show?
   end
 
   def new?
-    user.present?
+    show?
   end
 
   def update?
-    false
+    show?
   end
 
   def edit?
-    user.present?
+    show?
   end
 
   def destroy?
-    false
+    show?
   end
 
   class Scope

--- a/app/policies/wiki_policy.rb
+++ b/app/policies/wiki_policy.rb
@@ -23,4 +23,21 @@ class WikiPolicy < ApplicationPolicy
   def destroy?
     false
   end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      if user.role == 'admin' or user.role == 'premium'
+        scope.all
+      else 
+        scope.where(:public => true)
+      end
+    end
+  end
 end

--- a/app/policies/wiki_policy.rb
+++ b/app/policies/wiki_policy.rb
@@ -1,5 +1,26 @@
 class WikiPolicy < ApplicationPolicy
+  
+  def index?
+    false
+  end
+
+  def create?
+    user.present?
+  end
+
+  def new?
+    user.present?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    user.present?
+  end
+
   def destroy?
-    user.admin? || user.premium?
+    false
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -43,7 +43,7 @@
 <% end %>
 
 <h3>Downgrade Or Cancel Account</h3>
-<p><%= button_to "Downgrade To Standard", user_premium_to_standard_path(current_user), data: { confirm: 'Are you sure?' }, method: :post %></p>
+<p><%= button_to "Downgrade To Standard", user_premium_to_standard_path(current_user), data: { confirm: 'Are you sure? Private wikis will become Public.' }, method: :post %></p>
 <p><%= button_to "Cancel My Blocipedia Account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
 
 <%= link_to "Back", :back %>

--- a/app/views/wikis/_form.html.erb
+++ b/app/views/wikis/_form.html.erb
@@ -1,0 +1,7 @@
+<% if current_user.role == 'admin' || current_user.role == 'premium' %>
+    <div class="form-group">
+      <%= f.label :private, class: 'checkbox' do %>
+      <%= f.check_box :private %> Private wiki
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/wikis/_form.html.erb
+++ b/app/views/wikis/_form.html.erb
@@ -1,7 +1,7 @@
 <% if current_user.role == 'admin' || current_user.role == 'premium' %>
     <div class="form-group">
-      <%= label :private, class: 'checkbox' do %>
-      <%= check_box :private %> Private wiki
+      <%= f.label :private, class: 'checkbox' do %>
+      <%= f.check_box :private %> Private wiki
     <% end %>
 	</div>
 <% end %>

--- a/app/views/wikis/_form.html.erb
+++ b/app/views/wikis/_form.html.erb
@@ -1,7 +1,8 @@
 <% if current_user.role == 'admin' || current_user.role == 'premium' %>
     <div class="form-group">
       <%= f.label :private, class: 'checkbox' do %>
-      <%= f.check_box :private %> Private wiki
+      <%= f.check_box :public %> Private wiki
     <% end %>
 	</div>
+<% else %>
 <% end %>

--- a/app/views/wikis/_form.html.erb
+++ b/app/views/wikis/_form.html.erb
@@ -1,7 +1,7 @@
 <% if current_user.role == 'admin' || current_user.role == 'premium' %>
     <div class="form-group">
-      <%= f.label :private, class: 'checkbox' do %>
-      <%= f.check_box :private %> Private wiki
+      <%= label :private, class: 'checkbox' do %>
+      <%= check_box :private %> Private wiki
     <% end %>
-  </div>
+	</div>
 <% end %>

--- a/app/views/wikis/_public_private_button.html.erb
+++ b/app/views/wikis/_public_private_button.html.erb
@@ -1,0 +1,5 @@
+<% if wiki.public == true %>
+	<button type="button" class="btn btn-xs btn-primary">Public Wiki</button>
+<% else %>
+	<button type="button" class="btn btn-xs btn-success">Private Wiki</button>
+<% end %>

--- a/app/views/wikis/_public_private_button.html.erb
+++ b/app/views/wikis/_public_private_button.html.erb
@@ -1,4 +1,4 @@
-<% if wiki.public == true %>
+<% if @wiki.public == true %>
 	<button type="button" class="btn btn-xs btn-primary">Public Wiki</button>
 <% else %>
 	<button type="button" class="btn btn-xs btn-success">Private Wiki</button>

--- a/app/views/wikis/edit.html.erb
+++ b/app/views/wikis/edit.html.erb
@@ -23,11 +23,10 @@
          <%= f.submit "Save", class: 'btn btn-success' %>
        </div>
         <% if current_user.role == 'admin' || current_user.role == 'premium' %>
-        <div class="form-group">
-          <%= f.check_box :public, {}, false, true %> Private wiki
-        </div>
-  <% end %> 
-
+          <div class="form-group">
+            <%= f.check_box :public, {}, false, true %> Private wiki
+          </div>
+        <% end %> 
     <% end %>
 
    </div>

--- a/app/views/wikis/edit.html.erb
+++ b/app/views/wikis/edit.html.erb
@@ -22,7 +22,16 @@
        <div class="form-group">
          <%= f.submit "Save", class: 'btn btn-success' %>
        </div>
+       <% if current_user.role == 'admin' || current_user.role == 'premium' %>
+      <div class="form-group">
+        <%= f.label :public do %>
+        <%= f.check_box :public %> Private wiki
       <% end %>
+       </div>
+      <% else %>
+        <p>This wiki is <i>public</i></p>
+      <% end %>
+    <% end %>
    </div>
  </div>
 

--- a/app/views/wikis/edit.html.erb
+++ b/app/views/wikis/edit.html.erb
@@ -22,16 +22,13 @@
        <div class="form-group">
          <%= f.submit "Save", class: 'btn btn-success' %>
        </div>
-       <% if current_user.role == 'admin' || current_user.role == 'premium' %>
-      <div class="form-group">
-        <%= f.label :public do %>
-        <%= f.check_box :public %> Private wiki
-      <% end %>
-       </div>
-      <% else %>
-        <p>This wiki is <i>public</i></p>
-      <% end %>
+        <% if current_user.role == 'admin' || current_user.role == 'premium' %>
+        <div class="form-group">
+          <%= f.check_box :public, {}, false, true %> Private wiki
+        </div>
+  <% end %> 
+
     <% end %>
+
    </div>
  </div>
-

--- a/app/views/wikis/edit.html.erb
+++ b/app/views/wikis/edit.html.erb
@@ -22,7 +22,7 @@
        <div class="form-group">
          <%= f.submit "Save", class: 'btn btn-success' %>
        </div>
-     <% end %>
+      <% end %>
    </div>
  </div>
 

--- a/app/views/wikis/index.html.erb
+++ b/app/views/wikis/index.html.erb
@@ -6,6 +6,11 @@
 			<div class="media-body">
 				<h4 class="media-heading">
 					<%= link_to wiki.title, wiki %>
+					<% if wiki.public == true %>
+						<button type="button" class="btn btn-xs btn-primary">Public Wiki</button>
+					<% else %>
+						<button type="button" class="btn btn-xs btn-success">Private Wiki</button>
+					<% end %>
 				</h4>
 			</div>
 		</div>

--- a/app/views/wikis/index.html.erb
+++ b/app/views/wikis/index.html.erb
@@ -1,18 +1,24 @@
 <div class="container">
-<h1 class="text-center">All Wikis</h1>
-	<%= link_to "Create A New Wiki", new_wiki_path, class: 'btn btn-success' %>
-	<% @wikis.each do |wiki| %>
-		<div class="media">
-			<div class="media-body">
-				<h4 class="media-heading">
-					<%= link_to wiki.title, wiki %>
-					<% if wiki.public == true %>
-						<button type="button" class="btn btn-xs btn-primary">Public Wiki</button>
-					<% else %>
-						<button type="button" class="btn btn-xs btn-success">Private Wiki</button>
-					<% end %>
-				</h4>
-			</div>
+	<h1 class="text-center">All Wikis</h1>
+		<div class="col-md-12 text-center">
+				<%= link_to "Create A New Wiki", new_wiki_path, class: 'btn btn-lg btn-success center-block' %>
 		</div>
+</div>
+</br>
+	<table class="table">
+	<% @wikis.each do |wiki| %>
+	<tbody>
+		<tr>
+			<td>
+			<%= link_to wiki.title, wiki %>
+			<% if wiki.public == true %>
+				<button type="button" class="btn btn-xs btn-primary">Public Wiki</button>
+			<% else %>
+				<button type="button" class="btn btn-xs btn-success">Private Wiki</button>
+			<% end %>
+			</td>
+		</tr>
 	<% end %>
+	</tbody>
+	</table>
 </div>

--- a/app/views/wikis/new.html.erb
+++ b/app/views/wikis/new.html.erb
@@ -22,6 +22,11 @@
        <div class="form-group">
          <%= f.submit "Save", class: 'btn btn-success' %>
        </div>
+        <% if current_user.role == 'admin' || current_user.role == 'premium' %>
+          <div class="form-group">
+            <%= f.check_box :public, {}, false, true %> Private wiki
+          </div>
+        <% end %> 
      <% end %>
    </div>
  </div>

--- a/app/views/wikis/show.html.erb
+++ b/app/views/wikis/show.html.erb
@@ -3,5 +3,6 @@
 	<p><%= @wiki.body %></p>
 	<%= link_to "Edit", edit_wiki_path(@wiki), class: 'btn btn-xs btn-success' %>
 	<%= link_to "Delete", @wiki, method: :delete, class: 'btn btn-xs btn-danger', data: { confirm: 'Are you sure you want to delete this wiki?' } %>
+	<%= render partial: 'public_private_button' %>
 	<small>Post created <%= time_ago_in_words(@wiki.created_at)%> ago. Last updated on <%= @wiki.updated_at%>.</small>
 </div>

--- a/app/views/wikis/show.html.erb
+++ b/app/views/wikis/show.html.erb
@@ -1,7 +1,7 @@
 <div class="media">
 	<h1><%= @wiki.title %></h1>
 	<p><%= @wiki.body %></p>
-	<%= link_to "Edit", edit_wiki_path(@wiki), class: 'btn btn-success' %>
-	<%= link_to "Delete", @wiki, method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete this wiki?' } %>
+	<%= link_to "Edit", edit_wiki_path(@wiki), class: 'btn btn-xs btn-success' %>
+	<%= link_to "Delete", @wiki, method: :delete, class: 'btn btn-xs btn-danger', data: { confirm: 'Are you sure you want to delete this wiki?' } %>
 	<small>Post created <%= time_ago_in_words(@wiki.created_at)%> ago. Last updated on <%= @wiki.updated_at%>.</small>
 </div>

--- a/db/migrate/20150806181405_add_public_to_wikis.rb
+++ b/db/migrate/20150806181405_add_public_to_wikis.rb
@@ -1,0 +1,5 @@
+class AddPublicToWikis < ActiveRecord::Migration
+  def change
+    add_column :wikis, :public, :boolean
+  end
+end

--- a/db/migrate/20150806183305_drop_subscriptions_table.rb
+++ b/db/migrate/20150806183305_drop_subscriptions_table.rb
@@ -1,0 +1,5 @@
+class DropSubscriptionsTable < ActiveRecord::Migration
+  def change
+    drop_table :subscriptions
+  end
+end

--- a/db/migrate/20150810004149_remove_private_from_users.rb
+++ b/db/migrate/20150810004149_remove_private_from_users.rb
@@ -1,0 +1,5 @@
+class RemovePrivateFromUsers < ActiveRecord::Migration
+  def change
+    remove_column :users, :private, :boolean
+  end
+end

--- a/db/migrate/20150810004341_remove_private_from_wikis.rb
+++ b/db/migrate/20150810004341_remove_private_from_wikis.rb
@@ -1,0 +1,5 @@
+class RemovePrivateFromWikis < ActiveRecord::Migration
+  def change
+    remove_column :wikis, :private, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150806183305) do
+ActiveRecord::Schema.define(version: 20150810004341) do
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
@@ -40,7 +40,6 @@ ActiveRecord::Schema.define(version: 20150806183305) do
   create_table "wikis", force: :cascade do |t|
     t.string   "title"
     t.text     "body"
-    t.boolean  "private"
     t.integer  "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150729135355) do
+ActiveRecord::Schema.define(version: 20150806183305) do
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20150729135355) do
     t.integer  "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean  "public"
   end
 
   add_index "wikis", ["user_id"], name: "index_wikis_on_user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,13 +11,19 @@ require 'faker'
   user.save!
 end
 
+users = User.all
+
+random_boolean = [true,false].sample
+
 # Create Wikis
 50.times do
    Wiki.create!(
      title:  Faker::Lorem.sentence,
      body:   Faker::Lorem.paragraph,
      created_at: Faker::Date.between(14.days.ago, 7.days.ago),
-     updated_at: Faker::Date.between(6.days.ago, Date.today)
+     updated_at: Faker::Date.between(6.days.ago, Date.today),
+     user: users.sample,
+     public: random_boolean
    )
  end
  Wikis = Wiki.all

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,7 @@ end
 
 users = User.all
 
-random_boolean = [true,false].sample
+random_boolean = 
 
 # Create Wikis
 50.times do
@@ -23,7 +23,7 @@ random_boolean = [true,false].sample
      created_at: Faker::Date.between(14.days.ago, 7.days.ago),
      updated_at: Faker::Date.between(6.days.ago, Date.today),
      user: users.sample,
-     public: random_boolean
+     public: [true,false].sample
    )
  end
  Wikis = Wiki.all


### PR DESCRIPTION
- add more policies for `wiki` and `premium`/`admin` vs. `standard` users
- show different `wikis#index` for `standard` and `premium`/`admin` users
- allow `premium`/`admin` users to make public wikis private
- make private wikis public when author downgrades from `premium` to `standard`
- some refactoring of views
